### PR TITLE
OpenCV compatibility issue

### DIFF
--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -7,5 +7,5 @@ pillow
 scikit-learn
 click
 future
-opencv-python
+opencv-python==4.2.0.32
 tinydb

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -7,5 +7,5 @@ pillow
 scikit-learn
 click
 future
-opencv-python
+opencv-python==4.2.0.32
 tinydb


### PR DESCRIPTION
Python 2.7 support was dropped for newer opencv versions hence fixing old opencv version